### PR TITLE
Fix issues with IE9

### DIFF
--- a/lib/tiny-jsonrpc-postmessage/client.js
+++ b/lib/tiny-jsonrpc-postmessage/client.js
@@ -11,7 +11,7 @@ function PostMessageClient(config) {
   this._callbacks = {};
   this._serverOrigin = config.serverOrigin || null;
 
-  if (this._server instanceof global.Worker) {
+  if (global.Worker && this._server instanceof global.Worker) {
     this._server.addEventListener('message', this._onMessage.bind(this));
   } else {
     global.addEventListener('message', this._onMessage.bind(this));
@@ -25,17 +25,19 @@ PostMessageClient.prototype.constructor = PostMessageClient;
 
 PostMessageClient.prototype._send = function (request) {
   var success;
+  var requestStr;
 
   try {
-    JSON.stringify(request);
+    requestStr = JSON.stringify(request);
   } catch (e) {
     throw 'Could not serialize request to JSON';
   }
 
+  // send message as a string for IE9
   if (this._serverOrigin) {
-    this._server.postMessage(request, this._serverOrigin);
+    this._server.postMessage(requestStr, this._serverOrigin);
   } else {
-    this._server.postMessage(request);
+    this._server.postMessage(requestStr);
   }
 };
 
@@ -63,8 +65,17 @@ PostMessageClient.prototype.request = function () {
 };
 
 PostMessageClient.prototype._onMessage = function (e) {
-  if (!e.data || (!e.data.result && !e.data.error)) {
-    // ignore obviously invalid messages: they're not for us
+  var data;
+
+  try {
+    data = JSON.parse(e.data);
+  } catch (e) {
+    // ignore messages with data that isn't stringified: they're not for us
+    return;
+  }
+
+  if (!data.result && !data.error) {
+    // ignore invalid messages without results and errors
     return;
   }
 
@@ -73,7 +84,7 @@ PostMessageClient.prototype._onMessage = function (e) {
     return;
   }
 
-  var response = e.data;
+  var response = data;
 
   if (!util.isUndefined(response.id) && this._callbacks[response.id]) {
     this._callbacks[response.id](response.error || null,

--- a/lib/tiny-jsonrpc-postmessage/server.js
+++ b/lib/tiny-jsonrpc-postmessage/server.js
@@ -10,7 +10,7 @@ function PostMessageServer(config) {
 
   this._client = config.client || global;
 
-  if (this._client instanceof global.Worker) {
+  if (global.Worker && this._client instanceof global.Worker) {
     this._client.addEventListener('message', this._onMessage.bind(this));
   } else {
     global.addEventListener('message', this._onMessage.bind(this));
@@ -21,8 +21,17 @@ PostMessageServer.prototype = new Server();
 PostMessageServer.prototype.constructor = PostMessageServer;
 
 PostMessageServer.prototype._onMessage = function (e) {
-  if (!e.data || !e.data.method) {
-    // ignore obviously invalid messages: they're not for us
+  var data;
+
+  try {
+    data = JSON.parse(e.data);
+  } catch (e) {
+    // ignore messages with data that isn't stringified: they're not for us
+    return;
+  }
+
+  if (!data.method) {
+    // ignore messages without a method
     return;
   }
 
@@ -32,12 +41,13 @@ PostMessageServer.prototype._onMessage = function (e) {
   }
 
   var that = this;
-  this.respond(JSON.stringify(e.data), function (error, response) {
+  this.respond(JSON.stringify(data), function (error, response) {
     if (typeof response === 'string') {
+      // send message as a string for IE9
       if (e.origin) {
-        that._client.postMessage(JSON.parse(response), e.origin);
+        that._client.postMessage(response, e.origin);
       } else {
-        that._client.postMessage(JSON.parse(response));
+        that._client.postMessage(response);
       }
     }
   });

--- a/test/client.js
+++ b/test/client.js
@@ -169,11 +169,11 @@ test('PostMessageClient instances', function (t) {
       function (t) {
         var server = {
           postMessage: function (data) {
-            id = data.id;
+            id = JSON.parse(data).id;
           }
         };
         var callback = sinon.spy();
-        var messageHandler, id
+        var messageHandler, id, data;
 
         sinon.stub(global, 'addEventListener', function (event, handler) {
           messageHandler = handler;
@@ -186,23 +186,27 @@ test('PostMessageClient instances', function (t) {
 
         client.request('foo', callback);
 
+        data = {
+          jsonrpc: '2.0',
+          result: 'foo',
+          id: id
+        };
+
         messageHandler({
-          data: {
-            jsonrpc: '2.0',
-            result: 'foo',
-            id: id
-          }
+          data: JSON.stringify(data)
         });
 
         t.ok(!callback.called, 'callback not invoked if no origin');
 
+        data = {
+          jsonrpc: '2.0',
+          result: 'foo',
+          id: id
+        };
+
         messageHandler({
           origin: 'https://evil.com',
-          data: {
-            jsonrpc: '2.0',
-            result: 'foo',
-            id: id
-          }
+          data: JSON.stringify(data)
         });
 
         t.ok(
@@ -210,13 +214,15 @@ test('PostMessageClient instances', function (t) {
           'callback not invoked if origin is not serverOrigin'
         );
 
+        data = {
+          jsonrpc: '2.0',
+          result: 'foo',
+          id: id
+        };
+
         messageHandler({
           origin: 'https://example.com',
-          data: {
-            jsonrpc: '2.0',
-            result: 'foo',
-            id: id
-          }
+          data: JSON.stringify(data)
         });
 
         t.ok(callback.calledOnce, 'callback invoked if origin is serverOrigin');

--- a/test/server.js
+++ b/test/server.js
@@ -170,6 +170,16 @@ test('PostMessageServer instances', function (t) {
       });
       t.notOk(
         server.respond.called,
+        'does not call `this.respond` if data is an object'
+      );
+
+      messageHandler({
+        data: JSON.stringify({
+          foo: 'bar'
+        })
+      });
+      t.notOk(
+        server.respond.called,
         'does not call `this.respond` if no method'
       );
 
@@ -198,7 +208,7 @@ test('PostMessageServer instances', function (t) {
           params: []
         };
         messageHandler({
-          data: data
+          data: JSON.stringify(data)
         });
 
         t.ok(server.respond.calledOnce, 'calls `this.respond`');
@@ -239,12 +249,12 @@ test('PostMessageServer instances', function (t) {
           id: 1
         };
         messageHandler({
-          data: data
+          data: JSON.stringify(data)
         });
 
         t.ok(client.postMessage.calledOnce, 'postMessages client');
         t.deepEqual(
-          client.postMessage.firstCall.args[0],
+          JSON.parse(client.postMessage.firstCall.args[0]),
           {
             jsonrpc: '2.0',
             result: 'marco',
@@ -282,7 +292,7 @@ test('PostMessageServer instances', function (t) {
         id: 1
       };
       messageHandler({
-        data: data,
+        data: JSON.stringify(data),
         origin: 'http://example.com:1234'
       });
 
@@ -321,7 +331,7 @@ test('PostMessageServer instances', function (t) {
         id: 1
       };
       messageHandler({
-        data: data
+        data: JSON.stringify(data)
       });
 
       t.equal(
@@ -358,18 +368,18 @@ test('PostMessageServer instances', function (t) {
       };
 
       messageHandler({
-        data: data
+        data: JSON.stringify(data)
       });
       t.ok(!server.respond.called, 'ignores events without an origin');
 
       messageHandler({
-        data: data,
+        data: JSON.stringify(data),
         origin: 'https://foo.example.com'
       });
       t.ok(!server.respond.called, 'ignores events not from an allowed origin');
 
       messageHandler({
-        data: data,
+        data: JSON.stringify(data),
         origin: 'https://example.com'
       });
       t.ok(


### PR DESCRIPTION
This PR fixes a couple of issues I noticed in IE9. It adds a check for `Worker` since IE9 doesn't support it. Also, IE9 has issues when messages in `postMessage` are objects. So this PR changes the code to use strings instead.