### PR TITLE
Ignore messages that parse to a falsy value

### DIFF
--- a/lib/tiny-jsonrpc-postmessage/client.js
+++ b/lib/tiny-jsonrpc-postmessage/client.js
@@ -74,7 +74,7 @@ PostMessageClient.prototype._onMessage = function (e) {
     return;
   }
 
-  if (!data.result && !data.error) {
+  if (!data || (!data.result && !data.error)) {
     // ignore invalid messages without results and errors
     return;
   }

--- a/lib/tiny-jsonrpc-postmessage/server.js
+++ b/lib/tiny-jsonrpc-postmessage/server.js
@@ -47,7 +47,10 @@ PostMessageServer.prototype._onMessage = function (e) {
 
   var that = this;
   this.respond(JSON.stringify(data), function (error, response) {
-    if (typeof response === 'string') {
+    var id = parseInt(data.id, 10);
+
+    // response is a string and the request id was a number
+    if (typeof response === 'string' && id === id) {
       // send message as a string for IE9
       if (e.origin) {
         that._client.postMessage(response, e.origin);

--- a/test/client.js
+++ b/test/client.js
@@ -109,6 +109,58 @@ test('PostMessageClient instances', function (t) {
         t.end();
       });
 
+      t.test('listener', function (t) {
+        var server = {
+          postMessage: function (data) {
+            id = JSON.parse(data).id;
+          }
+        };
+        var callback = sinon.spy();
+        var messageHandler, id, data;
+
+        sinon.stub(global, 'addEventListener', function (event, handler) {
+          messageHandler = handler;
+        });
+
+        var client = new PostMessageClient({
+          server: server,
+          serverOrigin: 'https://example.com'
+        });
+
+        t.test('ignores messages where `e.data` cannot be parsed as JSON',
+          function (t) {
+            t.doesNotThrow(function () {
+              messageHandler({
+                data: 123
+              });
+            });
+            t.end();
+          });
+
+        t.test('ignores messages where `e.data` does not parse to an object',
+          function (t) {
+            t.doesNotThrow(function () {
+              messageHandler({
+                data: 'null'
+              });
+            });
+            t.end();
+          });
+
+        t.test('ignores messages where `e.data` is not an object',
+          function (t) {
+            t.doesNotThrow(function () {
+              messageHandler({
+                data: JSON.stringify({})
+              });
+            });
+            t.end();
+          });
+
+        global.addEventListener.restore();
+        t.end();
+      });
+
     t.end();
   });
 


### PR DESCRIPTION
Fix #13 by ignoring messages whose `data` member parses to a falsy value.

Also test that the `message` listener ignores other malformed messages.