### PR TITLE
Issue 15 support falsy results

### DIFF
--- a/lib/tiny-jsonrpc-postmessage/client.js
+++ b/lib/tiny-jsonrpc-postmessage/client.js
@@ -74,7 +74,7 @@ PostMessageClient.prototype._onMessage = function (e) {
     return;
   }
 
-  if (!data || (!data.result && !data.error)) {
+  if (!util.isObject(data) || !data || (!('result' in data) && !data.error)) {
     // ignore invalid messages without results and errors
     return;
   }
@@ -87,8 +87,10 @@ PostMessageClient.prototype._onMessage = function (e) {
   var response = data;
 
   if (!util.isUndefined(response.id) && this._callbacks[response.id]) {
-    this._callbacks[response.id](response.error || null,
-      response.result || null);
+    this._callbacks[response.id](
+      response.error || null,
+      'result' in data ? data.result : null
+    );
     delete this._callbacks[response.id];
   }
 };

--- a/test/client.js
+++ b/test/client.js
@@ -131,7 +131,7 @@ test('PostMessageClient instances', function (t) {
           function (t) {
             t.doesNotThrow(function () {
               messageHandler({
-                data: 123
+                data: ','
               });
             });
             t.end();


### PR DESCRIPTION
Previously, we checked for a response w/o a `result` or `error` by checking if
both are falsy. This is a valid (if imprecise) test for `error`. However, a
falsy `result` is valid. So, check for the presence of the property instead of
whether it's falsy.

Similarly, we decided to coerce `result` to `null` if it was falsy. Fix this in
the same manner.

Fix #15 

Also fix a broken test.